### PR TITLE
cmake fixes, generalizing container types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,5 @@ m4/lt~obsolete.m4
 /config
 
 *.deps
-
+dtps*
 *~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,21 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.4)
 project (nups)
 
 # The version number.
 set (nups_VERSION_MAJOR 0)
 set (nups_VERSION_MINOR 1)
+
+set(CMAKE_CXX_STANDARD 11)
+
+
+if (WIN32)
+	# disable autolinking in boost
+	add_definitions( -DBOOST_ALL_DYN_LINK )
+	add_definitions( -DBOOST_ALL_NO_LIB )
+	set(Boost_USE_MULTITHREADED 	ON)
+	set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS 1)
+endif()	
+
 
 # configure a header file to pass some of the CMake settings
 # to the source code
@@ -28,18 +40,24 @@ set(NUPS_SOURCES
 	src/nups.cpp
 	)
 
+
+include(GenerateExportHeader)
+
+
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 
-include_directories("${PROJECT_BINARY_DIR}")
+#include_directories("${PROJECT_BINARY_DIR}")
 
-#IF (BUILD_SHARED_LIBS)
-#	add_library(nups SHARED ${NUPS_HEADERS} ${NUPS_SOURCES})
-#ELSE ()
-#	
-#ENDIF(BUILD_SHARED_LIBS)
+add_library(nups SHARED ${NUPS_HEADERS} ${NUPS_SOURCES})
 
-add_library(nups STATIC ${NUPS_HEADERS} ${NUPS_SOURCES})
+generate_export_header(nups           
+    BASE_NAME nups
+    EXPORT_MACRO_NAME NUPS_EXPORTS
+    EXPORT_FILE_NAME nups_exports.h
+    STATIC_DEFINE SHARED_EXPORTS_BUILT_AS_STATIC)
+
+target_include_directories(nups PUBLIC ${CMAKE_BINARY_DIR})
 
 install(
 		TARGETS nups 
@@ -53,20 +71,13 @@ install(
 
 
 
+
+
 IF (BUILD_TESTING)
 	enable_testing()
 	#Setup CMake to run tests
 	
-	
-	add_definitions( -DBOOST_ALL_DYN_LINK )
-	
-	if (WIN32)
-		# disable autolinking in boost
-		add_definitions( -DBOOST_ALL_NO_LIB )
-		set(Boost_USE_MULTITHREADED 	ON)
-		
-	endif()	
-	
+
 	
 	#Prep for compiling against boost
 	find_package(Boost REQUIRED
@@ -74,7 +85,7 @@ IF (BUILD_TESTING)
 					unit_test_framework )
 	
 	INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIR})
-	LINK_DIRECTORIES(${Boost_LIBRARY_DIRS})
+	LINK_DIRECTORIES(${Boost_LIBRARY_DIRS} ${CMAKE_BINARY_DIR}/lib)
 	
 	
 	set(NUPS_TEST_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,9 @@
+#useful defines:
+
+# -DCMAKE_GENERATOR_PLATFORM=x64 or =x86
+
+
+
 cmake_minimum_required (VERSION 3.4)
 project (nups)
 
@@ -70,34 +76,30 @@ install(
 		DESTINATION "include/nups")
 
 
+enable_testing()
+#Setup CMake to run tests
 
 
 
-IF (BUILD_TESTING)
-	enable_testing()
-	#Setup CMake to run tests
-	
+#Prep for compiling against boost
+find_package(Boost REQUIRED
+			COMPONENTS 
+				unit_test_framework )
 
-	
-	#Prep for compiling against boost
-	find_package(Boost REQUIRED
-				COMPONENTS 
-					unit_test_framework )
-	
-	INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIR})
-	LINK_DIRECTORIES(${Boost_LIBRARY_DIRS} ${CMAKE_BINARY_DIR}/lib)
-	
-	
-	set(NUPS_TEST_SOURCES
-		test/nups_test.cpp)
-	
-	add_executable(nups_test ${NUPS_TEST_SOURCES}) 
-	target_link_libraries(nups_test ${Boost_LIBRARIES} nups)
+INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIR})
+LINK_DIRECTORIES(${Boost_LIBRARY_DIRS} ${CMAKE_BINARY_DIR}/lib)
 
-	add_test(NAME nups_test 
-			COMMAND ${CMAKE_BINARY_DIR}/bin/nups_test)
 
-ENDIF(BUILD_TESTING)
+set(NUPS_TEST_SOURCES
+	test/nups_test.cpp)
+
+add_executable(nups_test ${NUPS_TEST_SOURCES}) 
+target_link_libraries(nups_test ${Boost_LIBRARIES} nups)
+
+add_test(NAME nups_test 
+		COMMAND ${CMAKE_BINARY_DIR}/bin/nups_test)
+
+
 
 
 

--- a/include/nups/factor.hpp
+++ b/include/nups/factor.hpp
@@ -118,20 +118,21 @@ namespace nups {
 					throw std::runtime_error(error_message.str());
 				}
 
-				std::vector<NumT> re_scaled_coefficients(PolyT::Degree);
+				
 
 				if (p.size()==PolyT::Degree+1)
 				{
+					std::vector<NumT> re_scaled_coefficients(PolyT::Degree);
 					for (unsigned ii = 0; ii < PolyT::Degree; ++ii)
 						re_scaled_coefficients[ii] = p[ii] / p[PolyT::Degree];
+					// push off the factoring to the private function which assumes monic.
+					return static_cast< PolyT * >( this )->DoFactorMonic(r, s, re_scaled_coefficients);
 				}
 				else
 				{
-					for (unsigned ii = 0; ii < PolyT::Degree; ++ii)
-						re_scaled_coefficients[ii] = p[ii];
+					return static_cast< PolyT * >( this )->DoFactorMonic(r, s, p);
 				}
-				// push off the factoring to the private function which assumes monic.
-				return static_cast< PolyT * >( this )->DoFactorMonic(r, s, re_scaled_coefficients);
+				
 
 			}
 

--- a/include/nups/nups.hpp
+++ b/include/nups/nups.hpp
@@ -27,6 +27,8 @@
 #include "nups/polynomial_solve.hpp"
 #include "nups/linear_solve.hpp"
 #include "nups/predict.hpp"
+#include <nups_exports.h>
+
 
 extern "C"
 {

--- a/include/nups/polynomial_solve.hpp
+++ b/include/nups/polynomial_solve.hpp
@@ -220,6 +220,9 @@ namespace nups {
 				typedef typename NumTraits<CoeffT>::ComplexType Real;
 				typedef typename NumTraits<CoeffT>::ComplexType Complex;
 
+				if (coefficients.size()!=2)
+					throw std::runtime_error("solving a monic degree 2 polynomial requires 2 coefficients.");
+
 				solutions.resize(2);
 
 				Complex sqrt_discriminant = sqrt(pow(Complex(coefficients[1]),2) - Real(4)*Complex(coefficients[0]));
@@ -319,7 +322,7 @@ namespace nups {
 			\param corrects_during The number of Newton corrections taken after each step of the homotopy for the factorization.
 			\param corrects_after The number of Newton corrections taken after factorization, but before solution of the factored quartics.
 			*/
-			Octic(double final_tolerance, unsigned max_iterations_final = 10, unsigned steps = 10, unsigned corrects_during = 7, unsigned corrects_after = 10) : max_iterations_(max_iterations_final), final_tolerance_(final_tolerance), factorizer_(steps, corrects_during, corrects_after)
+			Octic(double final_tolerance, unsigned max_iterations_final = 5, unsigned steps = 3, unsigned corrects_during = 6, unsigned corrects_after = 6) : max_iterations_(max_iterations_final), final_tolerance_(final_tolerance), factorizer_(steps, corrects_during, corrects_after)
 			{
 			}
 
@@ -340,10 +343,11 @@ namespace nups {
 				if (coefficients.size()!=8)
 					throw std::runtime_error("solving a monic degree 8 polynomial requires 8 coefficients.");
 
-				std::vector<Complex> factor_coeffs_1, factor_coeffs_2;
-				factorizer_.Factor(factor_coeffs_1, factor_coeffs_2, coefficients);
+				std::vector<Complex> factor_coeffs_1(4), factor_coeffs_2(4);
+				std::vector<Complex> solns_temp_1(4), solns_temp_2(4);
 
-				std::vector<Complex> solns_temp_1, solns_temp_2;
+				factorizer_.Factor(factor_coeffs_1, factor_coeffs_2, coefficients);
+				
 				quartic_solver_.Solve(solns_temp_1, factor_coeffs_1);
 				quartic_solver_.Solve(solns_temp_2, factor_coeffs_2);
 
@@ -378,11 +382,11 @@ namespace nups {
 				if (coefficients.size()!=10)
 					throw std::runtime_error("solving a monic degree 10 polynomial requires 10 coefficients.");
 
-				std::vector<Complex> factor_coeffs_1, factor_coeffs_2;
+				std::vector<Complex> factor_coeffs_1(8), factor_coeffs_2(2);
 				factor::Decic<PredictorT,StartT>::Factor(factor_coeffs_1, factor_coeffs_2, coefficients);
 
 
-				std::vector<Complex> solns_temp_1, solns_temp_2;
+				std::vector<Complex> solns_temp_1(8), solns_temp_2(2);
 				octic_solver_.Solve(solns_temp_1, factor_coeffs_1);
 				quadratic_solver_.Solve(solns_temp_2, factor_coeffs_2);
 

--- a/include/nups/type_traits.hpp
+++ b/include/nups/type_traits.hpp
@@ -55,7 +55,7 @@ namespace nups
 
 		static float NewtonTerminationThreshold() 
 		{
-			return 1e-5f;
+			return 1e-6f;
 		}
 	};
 
@@ -70,7 +70,7 @@ namespace nups
 
 		static double NewtonTerminationThreshold() 
 		{
-			return 1e-11;
+			return 1e-12;
 		}
 	};
 
@@ -83,7 +83,7 @@ namespace nups
 
 		static double NewtonTerminationThreshold() 
 		{
-			return 1e-11;
+			return 1e-12;
 		}
 	};
 


### PR DESCRIPTION
this brings nups master up to date, with cmake file which works for visual studio 2015, on windows 10.  also, includes some template code which allows to use vector or valarray for container types.

it is possible that the templates for container type are slightly wrong, but they work in the test code, so...
